### PR TITLE
change to use line breaks for question&post contents

### DIFF
--- a/src/Form/PostType.php
+++ b/src/Form/PostType.php
@@ -7,6 +7,7 @@ namespace App\Form;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -16,7 +17,7 @@ class PostType  extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('subjectPost', TextType::class)
+            ->add('subjectPost', TextareaType::class)
             ->add('question_id', HiddenType::class);
 
         $builder->setMethod('POST');

--- a/templates/question/index.html.twig
+++ b/templates/question/index.html.twig
@@ -51,7 +51,7 @@
                         </div>
 
                         <div class="row question-row">
-                            {{ post.subject }}
+                            {{ post.subject |nl2br }}
                         </div>
                     </div>
                 </div>
@@ -90,7 +90,7 @@
 
                     {# Reply to question #}
                     <div class="col-9 question-answer-row">
-                        {{ post.subject }}
+                        {{ post.subject |nl2br }}
                     </div>
 
 


### PR DESCRIPTION
- changed the input type for post (text => textarea)
- added nl2br filters to the question & posts contents in the twig files

user can now use 'enter' key for line breaking and contents will be displayed with line breaks  
